### PR TITLE
Fix for backpack/quicksave

### DIFF
--- a/Projects/Android/jni/RTCWVR/VrInputDefault.c
+++ b/Projects/Android/jni/RTCWVR/VrInputDefault.c
@@ -132,7 +132,7 @@ void HandleInput_Default( ovrInputStateTrackedRemote *pDominantTrackedRemoteNew,
         resetCursor = qtrue;
 
         static bool canUseQuickSave = false;
-        if (pOffTracking->Status & (VRAPI_TRACKING_STATUS_POSITION_TRACKED | VRAPI_TRACKING_STATUS_POSITION_VALID)) {
+        if (pOffTracking->Status & VRAPI_TRACKING_STATUS_POSITION_TRACKED) {
             canUseQuickSave = false;
         }
         else if (!canUseQuickSave) {
@@ -207,7 +207,7 @@ void HandleInput_Default( ovrInputStateTrackedRemote *pDominantTrackedRemoteNew,
         static qboolean binocularstate = qfalse;
         qboolean binocularsactive = (vr.hasbinoculars && vr.backpackitemactive == 3 &&
                 (distanceToHMD < BINOCULAR_ENGAGE_DISTANCE) &&
-                (pDominantTracking->Status & (VRAPI_TRACKING_STATUS_POSITION_TRACKED | VRAPI_TRACKING_STATUS_POSITION_VALID)));
+                (pDominantTracking->Status & VRAPI_TRACKING_STATUS_POSITION_TRACKED));
         if (binocularstate != binocularsactive)
         {
             //Engage scope if conditions are right
@@ -308,7 +308,7 @@ void HandleInput_Default( ovrInputStateTrackedRemote *pDominantTrackedRemoteNew,
                 finishReloadNextFrame = false;
             }
 
-            if (pDominantTracking->Status & (VRAPI_TRACKING_STATUS_POSITION_TRACKED | VRAPI_TRACKING_STATUS_POSITION_VALID)) {
+            if (pDominantTracking->Status & VRAPI_TRACKING_STATUS_POSITION_TRACKED) {
                 canUseBackpack = false;
             }
             else if (!canUseBackpack && vr.backpackitemactive == 0) {


### PR DESCRIPTION
Dirty fix to detect controllers out of range (over the shoulder).

[SDK 1.23.0 release notes says](https://developer.oculus.com/downloads/package/oculus-mobile-sdk/1.23.0/):
_"When the \_TRACKED bit is unset, but the \_VALID bit is set, the provided pose is usable, but is the result of some model or estimation heuristic."_. So, apparently POSITION\_VALID flag is always set which makes backpack/quicksave modes unreachable. Changing detection code to look at POSITION\_TRACKED works, however that is triggered when controller is not tracked in any pose, not only when it's over the shoulder.

The proper fix will be to read controllers POSITION data relative to the headset position and trigger backpack only when controller approximately over the shoulder.
