### PR TITLE
Update App Shutdown

### DIFF
--- a/Projects/Android/jni/RTCWVR/RTCWVR_SurfaceView.c
+++ b/Projects/Android/jni/RTCWVR/RTCWVR_SurfaceView.c
@@ -145,7 +145,6 @@ static void *RTCWVR_AppThread(void *parm)
 
     VR_main(argc, argv);
 
-    TBXR_DestroySessionForReinit();
     RTCWVR_JniShutdown();
 
     return NULL;


### PR DESCRIPTION
- TBXR_DestroySessionForReinit() causes the game not to shutdown when you are in a level (removed it)